### PR TITLE
Make images wiki prominent

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -44,7 +44,6 @@ Learn
     Runtime Environment
       [/runtime/runtime]
       [/runtime/terminal]
-      [/runtime/resin-base-images]
       [/runtime/update-strategies]
       [/runtime/bandwidth-reduction]
 

--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -91,3 +91,4 @@ Reference
   CLI Reference[/tools/cli]
   Node.js SDK[/tools/sdk]
   Python SDK[/tools/python-sdk]
+  Base Images Wiki[/runtime/resin-base-images]

--- a/pages/introduction.md
+++ b/pages/introduction.md
@@ -8,6 +8,8 @@ title: Welcome to Resin.io
 
 To get started with resin.io, first read [understanding resin.io][understanding] or you can jump right in with [installing resin.io][installing] to start provisioning some devices and pushing code.
 
+If you need to work out which base image to use, check out our [base images wiki][base-images-wiki] which lists all of our base images including many specialised ones for e.g. node, python, go, smaller images, etc.
+
 Have fun!
 
 If you have any further questions drop us a mail at **hello@resin.io**.
@@ -15,3 +17,4 @@ If you have any further questions drop us a mail at **hello@resin.io**.
 [resin]:http://resin.io
 [installing]:/installing/gettingStarted
 [understanding]:/understanding/understanding-code-deployment
+[base-images-wiki]:/runtime/resin-base-images

--- a/pages/runtime/resin-base-images.md
+++ b/pages/runtime/resin-base-images.md
@@ -1,6 +1,6 @@
 # Resin Images Wiki
 
-This page contains all the information about the image maintained on the Resin.io docker hub registry.
+This page contains all the information about the images maintained on the Resin.io docker hub registry.
 
 ## <a name="image-tree"></a>Resin Image Trees
 

--- a/pages/runtime/resin-base-images.md
+++ b/pages/runtime/resin-base-images.md
@@ -1,4 +1,4 @@
-# Resin Images Wiki
+# Resin Base Images Wiki
 
 This page contains all the information about the images maintained on the Resin.io docker hub registry.
 

--- a/pages/tools/cli.md
+++ b/pages/tools/cli.md
@@ -600,6 +600,7 @@ by using the same option names as keys. For example:
 		- .git
 		- node_modules/
 	progress: true
+	verbose: false
 
 Notice that explicitly passed command options override the ones set in the configuration file.
 
@@ -609,6 +610,7 @@ Examples:
 	$ resin sync 7cf02a6
 	$ resin sync 7cf02a6 --port 8080
 	$ resin sync 7cf02a6 --ignore foo,bar
+	$ resin sync 7cf02a6 -v
 
 ### Options
 
@@ -632,6 +634,10 @@ show progress
 
 ssh port
 
+#### --verbose, -v
+
+increase verbosity
+
 # SSH
 
 ## ssh &#60;uuid&#62;
@@ -645,12 +651,17 @@ Examples:
 
 	$ resin ssh 7cf02a6
 	$ resin ssh 7cf02a6 --port 8080
+	$ resin ssh 7cf02a6 -v
 
 ### Options
 
 #### --port, -t &#60;port&#62;
 
 ssh gateway port
+
+#### --verbose, -v
+
+increase verbosity
 
 # Notes
 
@@ -729,7 +740,7 @@ drive
 
 ## config read
 
-Use this command to read the config.json file from a provisioned device
+Use this command to read the config.json file from the mounted filesystem (e.g. SD card) of a provisioned device"
 
 Examples:
 
@@ -748,7 +759,7 @@ drive
 
 ## config write &#60;key&#62; &#60;value&#62;
 
-Use this command to write the config.json file of a provisioned device
+Use this command to write the config.json file to the mounted filesystem (e.g. SD card) of a provisioned device
 
 Examples:
 
@@ -768,7 +779,7 @@ drive
 
 ## config inject &#60;file&#62;
 
-Use this command to inject a config.json file to a provisioned device
+Use this command to inject a config.json file to the mounted filesystem (e.g. SD card) of a provisioned device"
 
 Examples:
 


### PR DESCRIPTION
Increase prominence of Resin Base Images Wiki
    
Previously this was not so easily accessible, these changes rename the page to make use of the phrase 'base image' which is the more commonly known name for images, add a link to the page on the references tab and add a blurb about base images with a link to the introduction page.
    
Solves issue #248.