### PR TITLE
Improve runtime document: add environment file to systemd service

### DIFF
--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -175,6 +175,7 @@ In some cases its useful to set up a service that starts up when your container 
 Description=My Super Sweet Service
 
 [Service]
+EnvironmentFile=/etc/docker.env
 Type=OneShot
 ExecStart=/etc/init.d/my_super_sweet_service
 


### PR DESCRIPTION
I think it will be better if we add the environment file in the example service file since many users asked about this