### PR TITLE
add some category header pages

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -64,7 +64,7 @@ Learn
 
     Network Setup[/deployment/network]
 
-    3rd Party Integrations
+    3rd Party Integrations[/integrations]
       Amazon AWS IoT[/integrations/aws]
       IBM Bluemix[/integrations/bluemix]
       Microsoft Azure[/integrations/azure]
@@ -74,7 +74,7 @@ Learn
     Creating Custom Resin.io Devices[/hardware/meta-resin]
     Advanced resin.io topics[/advanced/resources]
 
-  Examples
+  Examples[/examples]
     [/examples/seed-projects]
     [/examples/snippets]
     [/examples/projects]

--- a/pages/examples.md
+++ b/pages/examples.md
@@ -1,0 +1,18 @@
+---
+title: Examples
+excerpt: Seed projects, snippets, and example code to inspire you
+---
+
+# Examples
+
+### Seed projects
+
+A list of [seed projects](seed-projects/), "hello world" applications written in different languages, which are designed to form the basis of your own projects written in each language.
+
+### Snippets
+
+[Snippets](snippets/) are a collection of base projects, that focus on specific functionality, and are a nice base to start a project from.
+
+### Projects
+
+Some awesome [projects](projects/) built using resin.io and are a lot more fully featured and complete than the code snippets.

--- a/pages/integrations.md
+++ b/pages/integrations.md
@@ -1,0 +1,15 @@
+---
+title: 3rd Party Integrations
+excerpt: Guides to integrate with a variety of IoT platforms
+---
+
+# 3rd Party Integrations
+
+Resin.io can be integrated with external 3rd party services, such as IoT messaging or data analytics platforms. Here are some guides to help you get started.
+
+### Guides
+
+* [Amazon AWS IoT](aws/)
+* [IBM BlueMix](bluemix/)
+* [Microsoft Azure](azure/)
+* [Samsung ARTIK Cloud](artik/)


### PR DESCRIPTION
Some of the categories are harder to understand, when clicking on the header
in the navigation bar takes the user right to the first item in the category.
It makes the other items in the category easy to miss in our navigation bar.
Add some category pages, from where the rest of the items are linked.