### PR TITLE
dbus updates

### DIFF
--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -141,6 +141,55 @@ DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket dbus-send --s
 DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reboot
 ```
 
+**Checking if device time NTP synchronized**
+```Bash
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket \
+  dbus-send \
+  --system \
+  --print-reply \
+  --reply-timeout=2000 \
+  --type=method_call \
+  --dest=org.freedesktop.timedate1 \
+  /org/freedesktop/timedate1  \
+  org.freedesktop.DBus.Properties.GetAll \
+  string:"org.freedesktop.timedate1"
+```
+
+The reply would look like this:
+```variant
+method return time=1474008856.507103 sender=:1.12 -> destination=:1.11 serial=4 reply_serial=2
+   array [
+      dict entry(
+         string "Timezone"
+         variant             string "UTC"
+      )
+      dict entry(
+         string "LocalRTC"
+         variant             boolean false
+      )
+      dict entry(
+         string "CanNTP"
+         variant             boolean true
+      )
+      dict entry(
+         string "NTP"
+         variant             boolean true
+      )
+      dict entry(
+         string "NTPSynchronized"
+         variant             boolean true
+      )
+      dict entry(
+         string "TimeUSec"
+         variant             uint64 1474008856505839
+      )
+      dict entry(
+         string "RTCTimeUSec"
+         variant             uint64 1474008857000000
+      )
+   ]
+```
+
 __Note:__ To use the `dbus-send` command in the example you will need to install the `dbus` package in your Dockerfile.
 
 ### Failed to install release agent

--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -156,7 +156,7 @@ DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket \
   org.freedesktop.systemd1.Manager.Reboot
 ```
 
-**Checking if device time NTP synchronized**
+**Checking if device time is NTP synchronized**
 ```Bash
 DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket \
   dbus-send \

--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -133,12 +133,27 @@ In some cases its necessary to communicate with the hostOS systemd to perform ac
 
 **Change the Device hostname**
 ```Bash
-DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.hostname1 /org/freedesktop/hostname1 org.freedesktop.hostname1.SetStaticHostname string:"YOUR-NEW-HOSTNAME" boolean:true
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket \
+  dbus-send \
+  --system \
+  --print-reply \
+  --reply-timeout=2000 \
+  --type=method_call \
+  --dest=org.freedesktop.hostname1 \
+  /org/freedesktop/hostname1 \
+  org.freedesktop.hostname1.SetStaticHostname \
+  string:"YOUR-NEW-HOSTNAME" boolean:true
 ```
 
 **Rebooting the Device**
 ```Bash
-DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reboot
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket \
+  dbus-send \
+  --system
+  --print-reply \
+  --dest=org.freedesktop.systemd1 \
+  /org/freedesktop/systemd1 \
+  org.freedesktop.systemd1.Manager.Reboot
 ```
 
 **Checking if device time NTP synchronized**

--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -270,3 +270,4 @@ On the hostOS in resin.io we use [dnsmasq][dnsmasq-link] to manage DNS. This mea
 [systemd-base-image-link]:https://hub.docker.com/r/resin/raspberrypi-python/
 [dnsmasq-link]:http://www.thekelleys.org.uk/dnsmasq/doc.html
 [udev-link]:https://www.freedesktop.org/software/systemd/man/udev.html
+[dbus-link]:https://www.freedesktop.org/wiki/Software/dbus/


### PR DESCRIPTION
Changes:
* add example of querying whether the device is NTP synchronized (actually came up in support, and it is different from the other two examples as it returns data)
* adjust formatting of `dbus-send` commands for better readability
* fix missing ling as per #332 