### PR TITLE
update Artik example code

### DIFF
--- a/pages/integrations/artik.md
+++ b/pages/integrations/artik.md
@@ -140,6 +140,7 @@ Then in your application you can access the environmental variables through `os.
 import os
 import time
 import artikcloud
+from artikcloud.rest import ApiException
 
 # Setting credentials from the environmental variables
 DEVICE_ID = os.getenv('ARTIKCLOUD_DEVICE_ID')
@@ -147,13 +148,13 @@ DEVICE_TOKEN = os.getenv('ARTIKCLOUD_DEVICE_TOKEN')
 
 # Setting up ARTIK Cloud connection
 api_client = artikcloud.ApiClient()
-api_client.set_default_header(header_name="Authorization", header_value="Bearer {}".format(DEVICE_TOKEN))
-
+# Setting up ARTIK Cloud connection
+artikcloud.configuration.access_token = DEVICE_TOKEN
 # Setting up messaging
-messages_api = artikcloud.MessagesApi(api_client)
+messages_api = artikcloud.MessagesApi()
 
 # Send a new message
-message = artikcloud.MessageAction()
+message = artikcloud.Message()
 message.type = "message"
 message.sdid = "{}".format(DEVICE_ID)
 message.ts = int(round(time.time() * 1000))  # timestamp, required

--- a/pages/integrations/artik.md
+++ b/pages/integrations/artik.md
@@ -207,24 +207,24 @@ var ArtikCloud = require('artikcloud-js');
 const device_id = process.env.ARTIKCLOUD_DEVICE_ID || null; // Required
 const device_token = process.env.ARTIKCLOUD_DEVICE_TOKEN || null; // Required
 
-var apiClient = new ArtikCloud.ApiClient();
+var defaultClient = ArtikCloud.ApiClient.default;
 
 // Setting up authentication
-var artikcloud_oauth = apiClient.authentications['artikcloud_oauth'];
+var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
 artikcloud_oauth.accessToken = device_token;
 
 // Get a new MessagesAPI connection
-messagesapi = new ArtikCloud.MessagesApi(apiClient);
+var messagesAPI = new ArtikCloud.MessagesApi()
 
 // Create a new message
-var message = new ArtikCloud.MessageAction();
+var message = new ArtikCloud.Message();
 message.sdid = device_id;
 message.type = 'message';
 message.ts = Date.now();  // timestamp, required
 message.data = { "Temperature": 25.4  };
 
 // Send message
-messagesapi.sendMessageAction(message, function(error, response) {
+messagesAPI.sendMessage(message, function(error, response) {
     if (error) {
         throw error;
     } else {


### PR DESCRIPTION
The ARTIK API has changed from the previous (2.0.3) version to the current (2.0.5), making our examples invalid. Fix them up.