### PR TITLE
Distinguish Param from Payload

### DIFF
--- a/pages/runtime/data-api.md
+++ b/pages/runtime/data-api.md
@@ -71,6 +71,9 @@ curl "{{ $links.apiBase }}application?\$filter=app_name%20eq%20'<name>'"
 Param | Type | Description
 ------|------|------------:
 app_name | `STRING` | application name
+
+Payload | Type | Description
+------|------|------------:
 device_type | `STRING` | device type
 
 * cURL Example:
@@ -317,6 +320,9 @@ curl "{{ $links.apiBase }}device(<ID>)?\$select=is_web_accessible"
 Param | Type | Description
 ------|------|------------:
 ID | `INTEGER` | device ID
+
+Payload | Type | Description
+------|------|------------:
 name | `STRING` | device new name
 
 * cURL Example:
@@ -353,6 +359,9 @@ curl -X DELETE '{{ $links.apiBase }}device(<ID>)'
 Param | Type | Description
 ------|------|------------:
 ID | `INTEGER` | device ID
+
+Payload | Type | Description
+------|------|------------:
 note | `STRING` | device new note
 
 * cURL Example:
@@ -382,6 +391,9 @@ curl -X PATCH "{{ $links.apiBase }}device(<ID>)"
 Param | Type | Description
 ------|------|------------:
 ID | `INTEGER` | device ID
+
+Payload | Type | Description
+------|------|------------:
 application | `INTEGER` | application ID
 
 * cURL Example:
@@ -428,7 +440,8 @@ curl "{{ $links.apiBase}}user__has__public_key(<ID>)"
 * Endpoint: `/user__has__public_key`
 * Method: `POST`
 
-Param | Type | Description
+
+Payload | Type | Description
 ------|------|------------:
 public_key | `STRING` | ssh key
 title | `STRING` | key title
@@ -486,7 +499,8 @@ curl "{{ $links.apiBase }}device_environment_variable?\$filter=device%20eq%20<ID
 * Endpoint: `/device_environment_variable`
 * Method: `POST`
 
-Param | Type | Description
+
+Payload | Type | Description
 ------|------|------------:
 device | `INTEGER` | device ID
 env_var_name | `STRING` | variable name
@@ -511,6 +525,9 @@ curl -X POST "{{ $links.apiBase }}device_environment_variable"
 Param | Type | Description
 ------|------|------------:
 ID | `INTEGER` | environment variable ID
+
+Payload | Type | Description
+------|------|------------:
 value | `STRING` | new variable value
 
 * cURL Example:
@@ -561,7 +578,8 @@ curl "{{ $links.apiBase }}environment_variable?\$filter=application%20eq%20<ID>"
 * Endpoint: `/environment_variable`
 * Method: `POST`
 
-Param | Type | Description
+
+Payload | Type | Description
 ------|------|------------:
 application | `INTEGER` | application ID
 name | `STRING` | variable name

--- a/pages/runtime/data-api.md
+++ b/pages/runtime/data-api.md
@@ -68,12 +68,10 @@ curl "{{ $links.apiBase }}application?\$filter=app_name%20eq%20'<name>'"
 * Endpoint: `/application`
 * Method: `POST` 
 
-Param | Type | Description
-------|------|------------:
-app_name | `STRING` | application name
 
 Payload | Type | Description
 ------|------|------------:
+app_name | `STRING` | application name
 device_type | `STRING` | device type
 
 * cURL Example:


### PR DESCRIPTION
This PR tries to fix the confusion that arise when Payload is Mixed with Param

From my understanding, we use Param to specify parameters that are passed with the URL.  This can be query params after the ? part of the URL or some placeholder in the case of something like `/device(<ID>)`.

On the other hand, what is written in the request body is Payload, which in the cURL examples are passed with the `-data` flag`.
