### PR TITLE
Standardize on `ENV VARNAME value` format in Dockerfiles

### DIFF
--- a/pages/runtime/runtime.md
+++ b/pages/runtime/runtime.md
@@ -14,7 +14,7 @@ For these reasons we have built an [init system][init-system-link] into most of 
 There are two ways of enabling the init system in your application. You can either add the following environment variable in your Dockerfile:
 ```Dockerfile
 # enable container init system.
-ENV INITSYSTEM=on
+ENV INITSYSTEM on
 ```
 or you can add an environment variable from the Dashboard by navigating to the `Environment Variables` menu item on the left and adding the variable as shown below:
 ![Enable init system](/img/common/app/app_initsystem_envvar.png)

--- a/shared/diveIntoCode/cpp.md
+++ b/shared/diveIntoCode/cpp.md
@@ -20,7 +20,7 @@ __Warning:__ If you deploy this code to a Raspberry Pi V1 or ZERO, then you will
 
 The next line is used to enable the [systemd][systemd-link] init within the container. This is useful for a number of reasons, like keeping the container open after application crash and handling `/dev` updates as new USB devices are plugged in. If you want don't want an init system, just set it to `off` or remove the line for the `Dockerfile`.
 ```Dockerfile
-ENV INITSYSTEM=on
+ENV INITSYSTEM on
 ```
 
 Next up we have 3 lines which install all the dependencies needed by the container, in this case we need to install `build-essentials` so we can compile our C++ code.

--- a/shared/diveIntoCode/go.md
+++ b/shared/diveIntoCode/go.md
@@ -18,7 +18,7 @@ Which tells the resin builder that this is the docker image we want as our base.
 
 The next line is used to enable the [systemd][systemd-link] init within the container. This is useful for a number of reasons, like keeping the container open after application crash and handling `/dev` updates as new USB devices are plugged in. If you want don't want an init system, just set it to `off` or remove the line for the `Dockerfile`.
 ```Dockerfile
-ENV INITSYSTEM=on
+ENV INITSYSTEM on
 ```
 
 Next up we have 3 lines which install all the dependencies needed by the container, in this case we don't need any dependencies so the lines are commented out.

--- a/shared/diveIntoCode/nodejs.md
+++ b/shared/diveIntoCode/nodejs.md
@@ -47,14 +47,14 @@ RUN JOBS=MAX npm install --production --unsafe-perm && npm cache clean && rm -rf
 COPY . ./
 
 # Enable systemd init system in container
-ENV INITSYSTEM=on
+ENV INITSYSTEM on
 
 # server.js will run when container starts up on the device
 CMD ["npm", "start"]
 ```
 After the `npm install` we copy the rest of our source code into the working directory, we do this after so that later builds can benefit from build caching. So we will only trigger a full npm install if we change something in `package.json`.
 
-The last 2 commands are runtime directives. The `ENV INITSYSTEM=on` is used to enable the [systemd][systemd-link] init within the container. This is useful for a number of reasons, like keeping the container open after application crash and handling `/dev` updates as new USB devices are plugged in. If you want don't want an init system, just set it to `off` or remove the line for the `Dockerfile`.
+The last 2 commands are runtime directives. The `ENV INITSYSTEM on` is used to enable the [systemd][systemd-link] init within the container. This is useful for a number of reasons, like keeping the container open after application crash and handling `/dev` updates as new USB devices are plugged in. If you want don't want an init system, just set it to `off` or remove the line for the `Dockerfile`.
 
 The last command, `CMD` is perhaps one of the most important. This command defines what will run at container start on your {{ $device.name }}, in our example we have told npm to start a process. It should be noted that you can only have **one** `CMD` per `Dockerfile`.
 

--- a/shared/diveIntoCode/rust.md
+++ b/shared/diveIntoCode/rust.md
@@ -20,7 +20,7 @@ __Warning:__ If you deploy this code to a Raspberry Pi V1 or ZERO, then you will
 
 The next line is used to enable the [systemd][systemd-link] init within the container. This is useful for a number of reasons, like keeping the container open after application crash and handling `/dev` updates as new USB devices are plugged in. If you want don't want an init system, just set it to `off` or remove the line for the `Dockerfile`.
 ```Dockerfile
-ENV INITSYSTEM=on
+ENV INITSYSTEM on
 ```
 
 Next up we have 3 lines which install all the dependencies needed by the container, in this case we need to install `build-essentials`, `curl` and `file` so we can compile our {{ $language.name }} code.


### PR DESCRIPTION
Switch from using `=`, and make sure everywhere used the same way.
Connects to #335.