### PR TITLE
Fix link to RPi official WiFi dongle

### DIFF
--- a/pages/hardware/wifi-dongles.md
+++ b/pages/hardware/wifi-dongles.md
@@ -47,5 +47,5 @@ your WiFi device prior to switching on your device to avoid instability.
 [connman]:http://en.wikipedia.org/wiki/ConnMan
 [connman-format]:http://git.kernel.org/cgit/network/connman/connman.git/tree/doc/config-format.txt
 
-[rpi-official-wifi]:https://www.raspberrypi.org/products/usb-wifi-dongle/
+[rpi-official-wifi]:https://www.raspberrypi.org/products/raspberry-pi-usb-wifi-dongle/
 [beaglebone-green-link]:http://www.seeed.cc/beaglebone_green/


### PR DESCRIPTION
The previous URL now 404s