### PR TITLE
local-mode: <short-uuid>.local push does not work

### DIFF
--- a/pages/learn/develop/local-mode.md
+++ b/pages/learn/develop/local-mode.md
@@ -54,11 +54,11 @@ Reporting scan results
 
 ## Push over a new project
 
-Now that we know where our device is on the network we can start pushing some code to it. To do this, we use the `resin local push` command. This command instructs the device to do a Docker build and then runs your container in the same configuration as the resin.io device supervisor supervisor would. You can either pass the command your device's IP address or `<short-uuid>.local` name. If you leave this out, you will be presented with a list of devices to choose from.
+Now that we know where our device is on the network we can start pushing some code to it. To do this, we use the `resin local push` command. This command instructs the device to do a Docker build and then runs your container in the same configuration as the resin.io device supervisor supervisor would. You can either pass the command your device's IP address or `<short-uuid>` name. If you leave this out, you will be presented with a list of devices to choose from.
 
 **Command**
 ```
-sudo resin local push f340127.local -s .
+sudo resin local push f340127 -s .
 ```
 **Output**
 ```


### PR DESCRIPTION
The usage of `<short-uuid>.local` in the push command does not work and results
in a error of the type:

```
Push failed. Error: Error while inspecting image local-app: Error: getaddrinfo ENOTFOUND
```

Instead using the IP address or just the `<short-uuid>` works as expected.

Change-type: patch