### PR TITLE
Note how to enable the supervisor API

### DIFF
--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -24,10 +24,10 @@ Inside your running container, you'll have access to a number of `RESIN_` namesp
 | `RESIN_DEVICE_TYPE`         |  The type of device the application is running on. |
 | `RESIN` 	                  |  The `RESIN=1` variable can be used by your software to detect that it is running on a resin.io device. 	|
 | `RESIN_SUPERVISOR_VERSION` 	|  The current version of the supervisor agent running on the device.	|
-| `RESIN_SUPERVISOR_API_KEY` 	|  Authentication key for the supervisor API. This makes sure requests to the supervisor are only coming from containers on the device. See the [Supervisor API reference][supervisor-api-link]	for detailed usage.|
-| `RESIN_SUPERVISOR_ADDRESS` 	|  The network address of the supervisor API. Default: `http://127.0.0.1:48484`	|
-| `RESIN_SUPERVISOR_HOST` 	  |  The IP address of the supervisor API.	Default: `127.0.0.1`|
-| `RESIN_SUPERVISOR_PORT` 	  |  The network port number for the supervisor API. Default: `48484`	|
+| `RESIN_SUPERVISOR_API_KEY` 	|  Authentication key for the supervisor API. This makes sure requests to the supervisor are only coming from containers on the device. . Note: this is not available by default and must be enabled with the `io.resin.features.supervisor-api` container label. See the [Supervisor API reference][supervisor-api-link]	for detailed usage. |
+| `RESIN_SUPERVISOR_ADDRESS` 	|  The network address of the supervisor API. Default: `http://127.0.0.1:48484`. Note: this is not available by default and must be enabled with the `io.resin.features.supervisor-api` container label. See the [Supervisor API reference][supervisor-api-link]	for detailed usage.	|
+| `RESIN_SUPERVISOR_HOST` 	  |  The IP address of the supervisor API.	Default: `127.0.0.1`. Note: this is not available by default and must be enabled with the `io.resin.features.supervisor-api` container label. See the [Supervisor API reference][supervisor-api-link]	for detailed usage.|
+| `RESIN_SUPERVISOR_PORT` 	  |  The network port number for the supervisor API. Default: `48484`. Note: this is not available by default and must be enabled with the `io.resin.features.supervisor-api` container label. See the [Supervisor API reference][supervisor-api-link]	for detailed usage.	|
 | `RESIN_API_KEY` 	          |  API key which can be used to authenticate requests to the resin.io backend. Can be used with resin SDK on the device. **WARNING** This API key gives the code full user permissions, so can be used to delete and update anything as you would on the Dashboard.  	|
 | `RESIN_HOST_OS_VERSION`     |  The version of the resin host OS. |
 | `RESIN_DEVICE_RESTART` 	    |  This is a internal mechanism for restarting containers and can be ignored as its not very useful to application code.  Example: `1.13.0`	|

--- a/pages/reference/supervisor/supervisor-api.md
+++ b/pages/reference/supervisor/supervisor-api.md
@@ -6,6 +6,21 @@ The Supervisor itself has its own API, with means for user applications to commu
 
 Only Supervisors after version 1.1.0 have this functionality, and some of the endpoints appeared in later versions (we've noted it down where this is the case). Supervisor version 1.1.0 corresponds to OS images downloaded after October 14th 2015.
 
+## Enabling the API
+
+The Supervisor API is not enabled by default, and must be enabled via a docker container label. Add the `io.resin.features.supervisor-api` to your container. For multicontainer applications, a `docker-compose.yml` file might look like this:
+
+```yaml
+services:
+  bringup:
+    # ...
+    network_mode: host
+    labels:
+      io.resin.features.supervisor-api: '1'
+```
+
+Note that the Supervisor API also only works for `network_mode` values of `bridge` and `host` at the moment.
+
 ## HTTP API reference
 
 The supervisor exposes an HTTP API on port 48484 (`RESIN_SUPERVISOR_PORT`).


### PR DESCRIPTION
I was confused why I didn't have the `RESIN_SUPERVISOR_ADDRESS` env variables et all after looking at the documentation. Turns out you have to turn it on! This adds some handy notes to let users know to enable the API if they want to use those env vars. 