### PR TITLE
Mixpanel: Dynamically get the token from api.resin.io/config

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -3,6 +3,9 @@ var Headroom = require('headroom.js')
 var hljs = require('highlight.js/lib/highlight')
 var languages = require('./langs.js')
 
+// Export jQuery
+window.jQuery = $
+
 // TODO use import and tree shake instead of whitelisting lang modules
 // https://bjacobel.com/2016/12/04/highlight-bundle-size/
 languages.forEach(function(langName) {

--- a/templates/_track.html
+++ b/templates/_track.html
@@ -12,14 +12,15 @@
 <!-- start Mixpanel -->
 <script type="text/javascript">(function(f,b){if(!b.__SV){var a,e,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");
 for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
-mixpanel.init("99eec53325d4f45dd0633abd719e3ff1");</script>
-<!-- end Mixpanel -->
 
-<script type="text/javascript">
+window.jQuery.get('https://api.resin.io/config', (config) => {
+  mixpanel.init(config.mixpanelToken, { host: 'https://api.resin.io/mixpanel' });
   document.addEventListener("DOMContentLoaded", function(event) {
     mixpanel.track('Docs', { page: location.href });
   });
+});
 </script>
+<!-- end Mixpanel -->
 
 <!-- GoSquared -->
 <script>


### PR DESCRIPTION
I had to export jQuery from the main script so I could access it in the
Mixpanel snippet in order to request `/config`.

We're also changing the host where we post Mixpanel events to, as we are
now going to have all events going through the API.

Change-type: patch