### PR TITLE
Modify the repo to support serving content on a subpath

### DIFF
--- a/config/doxx.coffee
+++ b/config/doxx.coffee
@@ -22,4 +22,5 @@ module.exports = {
   parseNav: true
   serializeNav: path.join(root, 'server', 'nav.json')
   buildLunrIndex: path.join(root, 'server', 'lunr_index.json')
+  pathPrefix: config.pathPrefix
 }

--- a/config/index.coffee
+++ b/config/index.coffee
@@ -1,28 +1,21 @@
 DOCS_SOURCE_DIR = 'pages'
-DOCS_DEST_DIR = 'contents'
-
 TEMPLATES_DIR = 'templates'
 PARTIALS_DIR = 'shared'
 
 DYNAMIC_DOCS = /.*(getting-started|overview|network).*/
 
-GITHUB_EDIT_PAGE_LINK = (process.env.GITHUB_MAIN + '/docs/edit/master') || 'https://github.com/resin-io/docs/edit/master'
-
-MAIN_SITE = process.env.MAIN_SITE || 'https://resin.io'
-DASHBOARD_SITE  = process.env.DASHBOARD_SITE || 'https://dashboard.resin.io'
-LOGO = '/img/logo.svg'
-BASE_URL = process.env.BASE_URL || 'https://docs.resin.io'
 FB_APP_ID = '221218511385682'
-DEFAULT_THUMBNAIL = '/img/docs-preview.png'
+
+DOMAIN = "https://#{process.env.DOMAIN || 'www.balena.io'}"
 
 MAIN_MENU_LINKS = [
   {
     "title": "What it's for",
-    "link": "#{MAIN_SITE}/usecases"
+    "link": "#{DOMAIN}/usecases"
   },
   {
     "title": "How it works",
-    "link": "#{MAIN_SITE}/how-it-works"
+    "link": "#{DOMAIN}/how-it-works"
   },
   {
     "title": "Community",
@@ -30,37 +23,37 @@ MAIN_MENU_LINKS = [
   },
   {
     "title": "Blog",
-    "link": "#{MAIN_SITE}/blog"
+    "link": "#{DOMAIN}/blog"
   },
   {
     "title": "Pricing",
-    "link": "#{MAIN_SITE}/pricing"
+    "link": "#{DOMAIN}/pricing"
   },
   {
     "title": "Team",
-    "link": "#{MAIN_SITE}/team"
+    "link": "#{DOMAIN}/team"
   },
   {
     "title": "Contact",
-    "link": "#{MAIN_SITE}/contact"
+    "link": "#{DOMAIN}/contact"
   }
 ]
 
 module.exports =
   docsExt: 'md'
   docsSourceDir: DOCS_SOURCE_DIR
-  docsDestDir: DOCS_DEST_DIR
+  docsDestDir: 'contents'
   templatesDir: TEMPLATES_DIR
   partialsDir: PARTIALS_DIR
   dynamicDocs: DYNAMIC_DOCS
-  editPageLink: GITHUB_EDIT_PAGE_LINK
+  editPageLink: 'https://github.com/resin-io/docs/edit/master'
   links: require('./links')
   names: require('./names')
+  pathPrefix: process.env.PATH_PREFIX || '/docs'
   layoutLocals:
-    mainSiteUrl: MAIN_SITE
-    dashboardUrl: DASHBOARD_SITE
-    logo: LOGO
-    baseUrl: BASE_URL
+    dashboardUrl: process.env.DASHBOARD_SITE || 'https://dashboard.resin.io'
+    logo: '/img/logo.svg'
+    baseUrl: process.env.BASE_URL || 'https://docs.resin.io'
     menuLinks: MAIN_MENU_LINKS
     fbAppId: FB_APP_ID
-    defaultThumbnail: DEFAULT_THUMBNAIL
+    defaultThumbnail: '/img/docs-preview.png'

--- a/config/links.coffee
+++ b/config/links.coffee
@@ -3,12 +3,6 @@
 
 RPI_PRODUCTS = 'https://www.raspberrypi.org/products'
 BB_PRODUCTS = 'https://beagleboard.org'
-GITHUB_MAIN = process.env.GITHUB_MAIN || 'https://github.com/balena-io'
-GITHUB_PROJECTS = process.env.GITHUB_PROJECTS || 'https://github.com/balena-io-projects'
-GITHUB_OS = process.env.GITHUB_OS || 'https://github.com/balena-os'
-API_BASE = process.env.API_BASE || 'https://api.balena-cloud.com/'
-MAIN_SITE = process.env.MAIN_SITE || 'https://balena.io'
-DASHBOARD_SITE = process.env.DASHBOARD_SITE || 'https://dashboard.balena-cloud.com'
 
 module.exports =
   raspberrypi:
@@ -17,9 +11,9 @@ module.exports =
   beaglebone:
     black: "#{BB_PRODUCTS}/black"
     green: "#{BB_PRODUCTS}/green"
-  githubMain: GITHUB_MAIN
-  githubProjects: GITHUB_PROJECTS
-  githubOS: GITHUB_OS
-  apiBase: API_BASE
-  mainSiteUrl: MAIN_SITE
-  dashboardUrl: DASHBOARD_SITE
+  githubMain: 'https://github.com/balena-io'
+  githubProjects: 'https://github.com/balena-io-projects'
+  githubOS: 'https://github.com/balena-os'
+  apiBase: process.env.API_BASE || 'https://api.balena-cloud.com/'
+  mainSiteUrl: '/'
+  dashboardUrl: process.env.DASHBOARD_SITE || 'https://dashboard.balena-cloud.com'

--- a/config/names.coffee
+++ b/config/names.coffee
@@ -7,15 +7,13 @@ OS_LOWER = process.env.OS_LOWER || 'balenaOS'
 OS_UPPER = (OS_LOWER.charAt(0).toUpperCase() + OS_LOWER.slice(1)) || 'BalenaOS'
 ENGINE_LOWER = process.env.ENGINE_LOWER || 'balenaEngine'
 ENGINE_UPPER = (ENGINE_LOWER.charAt(0).toUpperCase() + ENGINE_LOWER.slice(1))
-DOMAIN = process.env.DOMAIN || 'balena.io'
-DOMAIN_OS = process.env.DOMAIN_OS || 'balena.io/os'
-DOMAIN_ENGINE = process.env.DOMAIN_ENGINE || 'balena.io/engine'
+DOMAIN_OS = process.env.DOMAIN_OS || 'www.balena.io/os'
+DOMAIN_ENGINE = process.env.DOMAIN_ENGINE || 'www.balena.io/engine'
 BASE_IMAGES_LIB = process.env.BASE_IMAGES_LIB || 'resin'
 BASE_IMAGES_CORE = process.env.BASE_IMAGES_CORE || 'resin'
 
-
 module.exports =
-  company: 
+  company:
     lower: COMPANY_LOWER
     upper: COMPANY_UPPER
     allCaps: COMPANY_ALL_CAPS
@@ -32,4 +30,4 @@ module.exports =
   base:
     lib: BASE_IMAGES_LIB
     core: BASE_IMAGES_CORE
-  domain: DOMAIN
+  domain: process.env.DOMAIN || 'www.balena.io'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@resin.io/doxx": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@resin.io/doxx/-/doxx-0.10.1.tgz",
-      "integrity": "sha1-MCrSzKqomTOuktJktTKj6NEmn2c=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@resin.io/doxx/-/doxx-0.11.0.tgz",
+      "integrity": "sha512-BxO8monSHcmv0eyLB9QIdwgNktECM/UaeNU8k0v6CwdUCtEkVOh5y/QFfADamUJTbolWUkAPaB2da+VbCGGIFQ==",
       "requires": {
         "@resin.io/doxx-handlebars-helper": "^0.1.0",
         "@resin.io/doxx-utils": "^0.1.2",
@@ -29,7 +29,7 @@
     },
     "@resin.io/doxx-handlebars-helper": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@resin.io/doxx-handlebars-helper/-/doxx-handlebars-helper-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/@resin.io/doxx-handlebars-helper/-/doxx-handlebars-helper-0.1.1.tgz",
       "integrity": "sha1-OVQx9/ATALu/75RuvXez/n0uypU=",
       "requires": {
         "coffee-script": "^1.10.0",
@@ -39,7 +39,7 @@
     },
     "@resin.io/doxx-utils": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@resin.io/doxx-utils/-/doxx-utils-0.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/@resin.io/doxx-utils/-/doxx-utils-0.1.2.tgz",
       "integrity": "sha1-iRSTktw77spzA7tz9LVWbAilVgY=",
       "requires": {
         "coffee-script": "^1.10.0",
@@ -125,6 +125,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -624,9 +625,19 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -761,9 +772,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1002,6 +1013,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -1021,7 +1033,7 @@
     },
     "cheerio": {
       "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
       "integrity": "sha1-IJZI1QGEbelc3KZEDziaf1wp3I8=",
       "requires": {
         "CSSselect": "~0.4.0",
@@ -1032,7 +1044,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -1189,6 +1201,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
       "requires": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -1198,7 +1211,8 @@
         "wordwrap": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
         }
       }
     },
@@ -1331,9 +1345,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1819,9 +1833,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1939,9 +1953,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -2046,13 +2060,13 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       },
@@ -2286,6 +2300,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -2310,7 +2325,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -2327,12 +2343,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -2345,17 +2363,20 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -2395,7 +2416,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2427,7 +2449,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2550,6 +2573,7 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -2597,6 +2621,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2610,7 +2635,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2683,12 +2709,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -2764,7 +2792,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2822,7 +2851,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2860,6 +2890,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2911,7 +2942,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2935,6 +2967,7 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2968,6 +3001,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2978,6 +3012,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3006,6 +3041,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3061,7 +3097,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -3142,9 +3179,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3216,14 +3253,26 @@
       }
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "requires": {
-        "async": "^1.4.0",
+        "async": "^2.5.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "3.4.9",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+          "optional": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          }
+        }
       }
     },
     "handlebars-helpers": {
@@ -3476,7 +3525,7 @@
     },
     "htmlparser2": {
       "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
       "integrity": "sha1-amTHdjfAjG8w7CqBV6UzM758sF4=",
       "requires": {
         "domelementtype": "1",
@@ -3502,7 +3551,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3878,9 +3927,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3925,7 +3974,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -4047,11 +4096,12 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "lunr": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/lunr/-/lunr-0.7.2.tgz",
       "integrity": "sha1-eaMOky4hbLoWNUHuN6NgfBLNcoE="
     },
     "macaddress": {
@@ -4096,7 +4146,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
     "math-expression-evaluator": {
@@ -4104,6 +4154,11 @@
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "md5.js": {
       "version": "1.3.4",
@@ -4166,7 +4221,7 @@
     },
     "metalsmith-dynamic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-dynamic/-/metalsmith-dynamic-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/metalsmith-dynamic/-/metalsmith-dynamic-0.3.0.tgz",
       "integrity": "sha1-XfWUQMy7rsdppyWotw94MiYMmTo=",
       "requires": {
         "coffee-script": "^1.10.0",
@@ -4175,7 +4230,7 @@
     },
     "metalsmith-headings": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-headings/-/metalsmith-headings-0.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/metalsmith-headings/-/metalsmith-headings-0.1.0.tgz",
       "integrity": "sha1-O/OVJPqbK1pUIlOJHh/xq1djJw0=",
       "requires": {
         "cheerio": "^0.14.0"
@@ -4196,6 +4251,11 @@
         "multimatch": "^2.0.0"
       },
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4221,6 +4281,11 @@
         "multimatch": "^2.0.0"
       },
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4242,14 +4307,14 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
         }
       }
     },
     "metalsmith-permalinks": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-0.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-0.5.0.tgz",
       "integrity": "sha1-D+xbHwaHgowZjTO11HnMHOxLGh8=",
       "requires": {
         "debug": "~0.7.4",
@@ -4260,8 +4325,87 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "metalsmith-prefixoid": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/metalsmith-prefixoid/-/metalsmith-prefixoid-1.0.3.tgz",
+      "integrity": "sha1-AFwI/J/yarAjWvkPyrjjxa31Cs8=",
+      "requires": {
+        "htmlparser2": "3.8.3",
+        "multimatch": "2.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "integrity": "sha1-xa2kJTV7dEulSELr3OHI8L5UK28=",
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "minimatch": "^2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -4340,7 +4484,7 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mixin-deep": {
@@ -4385,9 +4529,9 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.0.0",
@@ -5509,7 +5653,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -5587,39 +5731,24 @@
       "integrity": "sha1-8wLktqlqCxb7kvFF4AffXdcR2k0="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -5972,6 +6101,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -6250,12 +6380,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.1",
@@ -6495,7 +6622,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "source-map": {
@@ -6508,7 +6635,7 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "requires": {
             "async": "~0.2.6",
@@ -6524,7 +6651,7 @@
         },
         "yargs": {
           "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
           "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "requires": {
             "camelcase": "^1.0.2",
@@ -6753,6 +6880,7 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
       "requires": {
         "source-map": "~0.5.1",
         "uglify-to-browserify": "~1.0.0",
@@ -6762,7 +6890,8 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -6783,7 +6912,7 @@
     },
     "underscore.string": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
     "union-value": {
@@ -7201,9 +7330,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -7267,6 +7396,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
       "requires": {
         "camelcase": "^1.0.2",
         "cliui": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,19 @@
   },
   "homepage": "https://github.com/resin-io/docs",
   "dependencies": {
-    "@resin.io/doxx": "0.10.1",
+    "@resin.io/doxx": "0.11.0",
     "bootstrap": "3.3.7",
     "bootstrap-select": "1.12.2",
     "coffee-script": "~1.10.0",
     "express": "^4.13.4",
+    "express-http-to-https": "1.1.4",
     "headroom.js": "0.9.3",
     "highlight.js": "9.11.0",
     "jquery": "3.2.1",
     "jquery-colorbox": "1.6.4",
     "lodash": "^4.11.1",
-    "ractive": "0.8.12",
-    "express-http-to-https": "1.1.4"
+    "metalsmith-prefixoid": "^1.0.3",
+    "ractive": "0.8.12"
   },
   "devDependencies": {
     "css-loader": "0.28.0",

--- a/pages/reference/sdk/python-sdk.md
+++ b/pages/reference/sdk/python-sdk.md
@@ -245,7 +245,7 @@ Tethering=false
 
 [Bluetooth]
 Enable=true
-Tethering=false'}, u'pubnubPublishKey': u'pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226', u'apiEndpoint': u'https://api.resin.io', u'connectivity': u'connman', u'deviceType': u'raspberrypi3', u'mixpanelToken': u'99eec53325d4f45dd0633abd719e3ff1', u'deltaEndpoint': u'https://delta.resin.io', u'appUpdatePollInterval': 60000, u'applicationId': 106640, u'registryEndpoint': u'registry.resin.io'}
+Tethering=false'}, u'pubnubPublishKey': u'pub-c-6cbce8db-bfd1-4fdf-a8c8-53671ae2b226', u'apiEndpoint': u'https://api.resin.io', u'connectivity': u'connman', u'deviceType': u'raspberrypi3', u'mixpanelToken': u'12345678912345678912345678912345', u'deltaEndpoint': u'https://delta.resin.io', u'appUpdatePollInterval': 60000, u'applicationId': 106640, u'registryEndpoint': u'registry.resin.io'}
         
 ### Function: grant_support_access(app_id, expiry_timestamp)
 

--- a/server/index.coffee
+++ b/server/index.coffee
@@ -13,11 +13,6 @@ app.use(redirectToHTTPS([/localhost:(\d{4})/]))
 doxx = Doxx(doxxConfig)
 doxx.configureExpress(app)
 
-{ ACME_CHALLENGE, ACME_RESPONSE } = process.env
-if ACME_CHALLENGE and ACME_RESPONSE
-  app.use "/.well-known/acme-challenge/#{ACME_CHALLENGE}", (req, res) ->
-    res.send(ACME_RESPONSE)
-
 { GOOGLE_VERIFICATION } = process.env
 if GOOGLE_VERIFICATION
   if not GOOGLE_VERIFICATION.match(/\.html$/)
@@ -28,7 +23,7 @@ if GOOGLE_VERIFICATION
 staticDir = path.join(__dirname, '..', 'static')
 contentsDir = path.join(__dirname, '..', config.docsDestDir)
 
-app.use(express.static(staticDir))
+app.use("#{config.pathPrefix}/", express.static(staticDir))
 
 app.use (req, res, next) ->
   originalUrl = req.originalUrl
@@ -42,7 +37,7 @@ getLocals = (extra) ->
 
 doxx.loadLunrIndex()
 
-app.get '/search-results', (req, res) ->
+app.get "#{config.pathPrefix}/search-results", (req, res) ->
   { searchTerm } = req.query
   res.render 'search', getLocals
     title: "Search results for \"#{searchTerm}\""
@@ -53,7 +48,8 @@ app.get '/search-results', (req, res) ->
     searchTerm: searchTerm
     searchResults: doxx.lunrSearch(searchTerm)
 
-app.use(express.static(contentsDir))
+console.error("#{config.pathPrefix}/")
+app.use("#{config.pathPrefix}/", express.static(contentsDir))
 
 app.get '*', (req, res) ->
   res.render 'not-found', getLocals

--- a/templates/default.html
+++ b/templates/default.html
@@ -10,7 +10,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{{ title }} - {{ $names.company.upper }} Documentation" />
     {% if excerpt %}<meta property="og:description" content="{{ excerpt }}" />{% endif %}
-    <meta property="og:image" content="{{ baseUrl }}{% if thumbnail %}{{ thumbnail }}{% else %}{{ defaultThumbnail }}{% endif %}" />
+    <meta property="og:image" content="{% if thumbnail %}{{ thumbnail }}{% else %}{{ defaultThumbnail }}{% endif %}" />
     <link rel="stylesheet" href="/dist/style.css">
     <!-- Algolia search styles -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />


### PR DESCRIPTION
The path defaults to /docs, but can be overridden by setting
`PATH_PREFIX` as an env var. To actually work, this will require a newer
version of resin-io/doxx. PR coming for that repo.

Change-type: major
Signed-off-by: Jack Brown <jack@balena.io>